### PR TITLE
Move definition of OCIAPIConfig and OCIAPI to types.

### DIFF
--- a/cmd/ocidist/cmd/images.go
+++ b/cmd/ocidist/cmd/images.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/raharper/ocidist/pkg/api"
+	"github.com/raharper/ocidist/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -50,7 +51,7 @@ func doImages(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config := &api.OCIAPIConfig{TLSVerify: tlsVerify}
+	config := &types.OCIAPIConfig{TLSVerify: tlsVerify}
 	ociApi, err := api.NewOCIAPI(rawURL, config)
 	if err != nil {
 		return err

--- a/cmd/ocidist/cmd/inspect.go
+++ b/cmd/ocidist/cmd/inspect.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/raharper/ocidist/pkg/api"
+	"github.com/raharper/ocidist/pkg/types"
 
-	"github.com/containers/image/v5/types"
+	itypes "github.com/containers/image/v5/types"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +60,7 @@ type InspectOutput struct {
 	Architecture  string
 	Os            string
 	Layers        []string
-	LayersData    []types.ImageInspectLayer `json:",omitempty"`
+	LayersData    []itypes.ImageInspectLayer `json:",omitempty"`
 	Env           []string
 }
 
@@ -83,7 +84,7 @@ func doInspect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	apiConfig := &api.OCIAPIConfig{TLSVerify: tlsVerify}
+	apiConfig := &types.OCIAPIConfig{TLSVerify: tlsVerify}
 	ociApi, err := api.NewOCIAPI(rawURL, apiConfig)
 	if err != nil {
 		return err
@@ -125,7 +126,7 @@ func doInspect(cmd *cobra.Command, args []string) error {
 		Env:          img.Config.Env,
 	}
 
-	if ociApi.Type() == api.OCIDistRepoType {
+	if ociApi.Type() == types.OCIDistRepoType {
 		output.Name = ociApi.ImageName()
 	}
 

--- a/cmd/ocidist/cmd/repos.go
+++ b/cmd/ocidist/cmd/repos.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/raharper/ocidist/pkg/api"
+	"github.com/raharper/ocidist/pkg/types"
 
 	"github.com/spf13/cobra"
 )
@@ -42,7 +43,7 @@ func doRepos(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	config := &api.OCIAPIConfig{TLSVerify: tlsVerify}
+	config := &types.OCIAPIConfig{TLSVerify: tlsVerify}
 	ociApi, err := api.NewOCIAPI(rawURL, config)
 	if err != nil {
 		return err

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,39 +6,11 @@ import (
 	"os"
 
 	"github.com/raharper/ocidist/pkg/image"
-
-	dspec "github.com/opencontainers/distribution-spec/specs-go/v1"
-	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/raharper/ocidist/pkg/noci"
+	"github.com/raharper/ocidist/pkg/types"
 )
 
-type OCIRepoType string
-
-const (
-	OCIDirRepoType  OCIRepoType = "oci"
-	OCIDistRepoType OCIRepoType = "ocidist"
-)
-
-type OCIAPI interface {
-	Type() OCIRepoType
-
-	GetRepoTags() ([]string, error)
-	GetRepositories() ([]string, error)
-
-	GetRepoTagList() (*dspec.TagList, error)
-	GetManifest() (*ispec.Manifest, []byte, error)
-	GetImage(*ispec.Descriptor) (*ispec.Image, error)
-
-	ImageName() string
-	SourceURL() string
-	RepoPath() string
-	RepoTag() string
-}
-
-type OCIAPIConfig struct {
-	TLSVerify bool
-}
-
-func NewOCIAPI(rawURL string, config *OCIAPIConfig) (OCIAPI, error) {
+func NewOCIAPI(rawURL string, config *types.OCIAPIConfig) (types.OCIAPI, error) {
 
 	url, err := url.Parse(rawURL)
 	if err != nil {
@@ -50,6 +22,8 @@ func NewOCIAPI(rawURL string, config *OCIAPIConfig) (OCIAPI, error) {
 		return NewOCIDistRepo(url, config)
 	case "oci":
 		return NewOCIDirRepo(url, config)
+	case "noci":
+		return noci.NewRepo(url, config)
 	}
 
 	return nil, fmt.Errorf("Unknown URL scheme '%s' in url '%s'", url.Scheme, rawURL)

--- a/pkg/api/oci.go
+++ b/pkg/api/oci.go
@@ -10,24 +10,25 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/raharper/ocidist/pkg/types"
+
 	dspec "github.com/opencontainers/distribution-spec/specs-go/v1"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/opencontainers/umoci"
+	log "github.com/sirupsen/logrus"
 )
 
 type OCIDirRepo struct {
 	url    *url.URL
-	config *OCIAPIConfig
+	config *types.OCIAPIConfig
 }
 
-func NewOCIDirRepo(url *url.URL, config *OCIAPIConfig) (*OCIDirRepo, error) {
+func NewOCIDirRepo(url *url.URL, config *types.OCIAPIConfig) (*OCIDirRepo, error) {
 	return &OCIDirRepo{url: url, config: config}, nil
 }
 
-func (odr *OCIDirRepo) Type() OCIRepoType {
-	return OCIDirRepoType
+func (odr *OCIDirRepo) Type() types.OCIRepoType {
+	return types.OCIDirRepoType
 }
 
 func (odr *OCIDirRepo) OCIDir() string {

--- a/pkg/api/ocidist.go
+++ b/pkg/api/ocidist.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/raharper/ocidist/pkg/types"
+
 	"github.com/bloodorangeio/reggie"
 	dspec "github.com/opencontainers/distribution-spec/specs-go/v1"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -20,15 +22,15 @@ const (
 
 type OCIDistRepo struct {
 	url    *url.URL
-	config *OCIAPIConfig
+	config *types.OCIAPIConfig
 	// TODO add client
 }
 
-func (odr *OCIDistRepo) Type() OCIRepoType {
-	return OCIDistRepoType
+func (odr *OCIDistRepo) Type() types.OCIRepoType {
+	return types.OCIDistRepoType
 }
 
-func NewOCIDistRepo(url *url.URL, config *OCIAPIConfig) (*OCIDistRepo, error) {
+func NewOCIDistRepo(url *url.URL, config *types.OCIAPIConfig) (*OCIDistRepo, error) {
 	return &OCIDistRepo{url: url, config: config}, nil
 }
 

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -15,6 +15,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
 	"github.com/pkg/errors"
+	"github.com/raharper/ocidist/pkg/noci"
 )
 
 var urlSchemes map[string]func(string) (types.ImageReference, error)
@@ -33,6 +34,7 @@ func init() {
 	RegisterURLScheme("ocidist", docker.ParseReference)
 	RegisterURLScheme("docker", docker.ParseReference)
 	RegisterURLScheme("docker-daemon", daemon.ParseReference)
+	RegisterURLScheme("noci", noci.ParseReference)
 }
 
 func localRefParser(ref string) (types.ImageReference, error) {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	dspec "github.com/opencontainers/distribution-spec/specs-go/v1"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type OCIRepoType string
+
+const (
+	OCIDirRepoType  OCIRepoType = "oci"
+	OCIDistRepoType OCIRepoType = "ocidist"
+)
+
+type OCIAPI interface {
+	Type() OCIRepoType
+
+	GetRepoTags() ([]string, error)
+	GetRepositories() ([]string, error)
+
+	GetRepoTagList() (*dspec.TagList, error)
+	GetManifest() (*ispec.Manifest, []byte, error)
+	GetImage(*ispec.Descriptor) (*ispec.Image, error)
+
+	ImageName() string
+	SourceURL() string
+	RepoPath() string
+	RepoTag() string
+}
+
+type OCIAPIConfig struct {
+	TLSVerify bool
+}


### PR DESCRIPTION
I needed to do this because I am trying to add a new 'OCIAPI' type of 'noci' (nested oci) and wanted to hook it into api.NewOCIAPI.

Doing so would cause me an import loop, where
   * api.NewOCIApi woudl have to import noci to call noci.NewRepo
   * noci.NewRepo has to import and use pkg/api because it needs to return a api.OCIAPI