### PR TITLE
 Add support for working a Signed OCI (SOCI) image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINS := bin/ocidist
-TAGS := containers_image_openpgp
+TAGS := containers_image_openpgp -s -w
 
 .PHONY: all clean
 all: $(BINS)

--- a/cmd/ocidist/cmd/soci.go
+++ b/cmd/ocidist/cmd/soci.go
@@ -1,0 +1,139 @@
+/*
+Copyright © 2023 Ryan Harper <rharper@woxford.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/raharper/ocidist/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+var sociCmd = &cobra.Command{
+	Use:   "soci <cmd>",
+	Short: "manage Signed OCI (soci) images",
+}
+
+var sociInspectCmd = &cobra.Command{
+	Use:   "inspect <URI>",
+	Short: "inspect a Signed OCI (soci) image",
+	RunE:  runSociInspect,
+}
+
+var sociGetCmd = &cobra.Command{
+	Use:   "get <URI>",
+	Short: "get a Signed OCI (soci) image",
+	Long: `
+$ ocidist soci get ocidist://localhost:5000/product/services/svc:v1.2
+{
+ "install": {},
+ "pubkeycrt": {},
+ "signature": {},
+}
+`,
+	RunE: runSociGet,
+}
+
+func runSociInspect(cmd *cobra.Command, args []string) error {
+	rawURL := args[0]
+	if rawURL == "" {
+		return fmt.Errorf("Missing URL argument")
+	}
+	cmd.SilenceUsage = true
+
+	tlsVerify, err := cmd.Flags().GetBool("tls-verify")
+	if err != nil {
+		return err
+	}
+
+	config := &api.OCIAPIConfig{TLSVerify: tlsVerify}
+	ociApi, err := api.NewOCIAPI(rawURL, config)
+	if err != nil {
+		return err
+	}
+
+	sociRef, err := api.NewSOCIRef(ociApi)
+	if err != nil {
+		return err
+	}
+
+	info := api.SOCIInfo{
+		Ref:          ociApi.ImageName(), // sociRef.ImageName()? or sociRef.API.ImageName()?
+		Digest:       sociRef.Digest.String(),
+		InstallLayer: fmt.Sprintf("%s: %s", sociRef.Install.Digest.String(), sociRef.Manifest.ArtifactType),
+		Referrers: []string{
+			fmt.Sprintf("%s: %s", sociRef.Signature.Digest.String(), sociRef.Signature.ArtifactType),
+			fmt.Sprintf("%s: %s", sociRef.PubKeyCrt.Digest.String(), sociRef.PubKeyCrt.ArtifactType),
+		},
+	}
+
+	_, verifyInfo, _ := sociRef.Verify(cmd.Flag("ca-file").Value.String())
+	info.Verification = verifyInfo
+
+	content, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", content)
+	return nil
+}
+
+func runSociGet(cmd *cobra.Command, args []string) error {
+	rawURL := args[0]
+	if rawURL == "" {
+		return fmt.Errorf("Missing URL argument")
+	}
+	cmd.SilenceUsage = true
+
+	tlsVerify, err := cmd.Flags().GetBool("tls-verify")
+	if err != nil {
+		return err
+	}
+
+	config := &api.OCIAPIConfig{TLSVerify: tlsVerify}
+	ociApi, err := api.NewOCIAPI(rawURL, config)
+	if err != nil {
+		return err
+	}
+
+	sociRef, err := api.NewSOCIRef(ociApi)
+	if err != nil {
+		return err
+	}
+
+	sociArtifacts, err := sociRef.GetArtifacts()
+	if err != nil {
+		return err
+	}
+	content, err := json.MarshalIndent(sociArtifacts, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", content)
+
+	return nil
+}
+
+func init() {
+	sociInspectCmd.PersistentFlags().StringP("ca-file", "c", "", "verify soci cert is issued from specified CA and still valid")
+
+	sociCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
+
+	sociCmd.AddCommand(sociInspectCmd)
+	sociCmd.AddCommand(sociGetCmd)
+	rootCmd.AddCommand(sociCmd)
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -27,6 +27,8 @@ type OCIAPI interface {
 	GetRepoTagList() (*dspec.TagList, error)
 	GetManifest() (*ispec.Manifest, []byte, error)
 	GetImage(*ispec.Descriptor) (*ispec.Image, error)
+	GetReferrers(*ispec.Descriptor) (*ispec.Index, error)
+	GetBlob(*ispec.Descriptor) ([]byte, error)
 
 	ImageName() string
 	SourceURL() string


### PR DESCRIPTION
A signed OCI (SOCI) is a metadata OCI Image which includes:

- an install manifest which specifies what container images to install,
  some container config, and where the container is pulled from.
- a sigature of the install manifest by a private key
- the public key of the signing key

With these three elements, a SOCI aware system can verify the containers
it will install are from a trusted source (assuming you trust the
signer) and will install and run a certain way without being tampered.

Implement a SOCIRef api to inspect and get the compoents.

Verify and display information about the SOCI
```
$ ocidist soci inspect ocidist://host:port/path/to/install:version
{
  "ref": "localhost:port/path/to/install",
  "digest": "sha256:7fc237c91afc12bb3e1c8a38d30e3726681ded527674947a4727ed566398adec",
  "install-layer": "sha256:702e4c91f2cf3c0e1186e43949be3363b89acb1227dacecc6299c3524b46f276: application/vnd.atomix.install",
  "referrers": [
    "sha256:90f361b50c8634a9401b544817a91f5494979f3fadce2fea98fa1f56c16ebcf1: application/vnd.atomix.signature",
    "sha256:dca5d1c5882660fbb3921269aaa760518108895b36eb49994b38c3530e0db91c: application/vnd.atomix.pubkeycrt"
  ],
  "verification": "Verified OK"
}
```

Extract the SOCI artifacts
```
 $ ocidist soci get ocidist://host:port/path/to/install:version
 {
    "install": <install manifest>,
    "pubkeycrt": <cert here>,
    "signature": {
        "encoding": "base64",
        "data": <b64(signature)>,
    },
}
```
Signed-off-by: Ryan Harper <rharper@woxford.com>
