### PR TITLE
Fix inspect against docker:// scheme

### DIFF
--- a/cmd/ocidist/cmd/copy.go
+++ b/cmd/ocidist/cmd/copy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,7 +32,8 @@ $ ocidist copy ocidist://localhost:5000/myrepo/myimage:v2.1 oci:///ocidir/myrepo
 ...
 OK
 `,
-	RunE: doCopy,
+	RunE:    doCopy,
+	PreRunE: doBeforeRunCmd,
 }
 
 func doCopy(cmd *cobra.Command, args []string) error {
@@ -58,6 +59,6 @@ func doCopy(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(copyCmd)
+	copyCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug output")
 	copyCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
-
 }

--- a/cmd/ocidist/cmd/images.go
+++ b/cmd/ocidist/cmd/images.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,8 @@ $ ocidist images ocidist://localhost:5000/myrepo/myimage
 myimage:v1
 myimage:v2
 `,
-	RunE: doImages,
+	RunE:    doImages,
+	PreRunE: doBeforeRunCmd,
 }
 
 func doImages(cmd *cobra.Command, args []string) error {
@@ -79,6 +80,7 @@ func doImages(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(imagesCmd)
+	imagesCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug output")
 	imagesCmd.PersistentFlags().BoolP("tags-only", "t", false, "print image tags only")
 	imagesCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
 }

--- a/cmd/ocidist/cmd/inspect.go
+++ b/cmd/ocidist/cmd/inspect.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,8 @@ $ ocidist inspect ocidist://localhost:5000/myrepo/myimage:v2.1
   ],
   ...
 }`,
-	RunE: doInspect,
+	RunE:    doInspect,
+	PreRunE: doBeforeRunCmd,
 }
 
 // github.com/containers/skopeo/cmd/skopeo/inspect/output.go:Output
@@ -141,6 +142,7 @@ func doInspect(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(inspectCmd)
+	inspectCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug output")
 	inspectCmd.PersistentFlags().BoolP("config", "c", false, "output configuration")
 	inspectCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
 	inspectCmd.PersistentFlags().BoolP("raw", "r", false, "output raw manifest or configuration")

--- a/cmd/ocidist/cmd/repos.go
+++ b/cmd/ocidist/cmd/repos.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -31,7 +31,8 @@ var reposCmd = &cobra.Command{
 	Long: `
 $ ocidist repos ocidist://localhost:5000
 `,
-	RunE: doRepos,
+	RunE:    doRepos,
+	PreRunE: doBeforeRunCmd,
 }
 
 func doRepos(cmd *cobra.Command, args []string) error {
@@ -61,5 +62,6 @@ func doRepos(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rootCmd.AddCommand(reposCmd)
+	reposCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug output")
 	reposCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
 }

--- a/cmd/ocidist/cmd/root.go
+++ b/cmd/ocidist/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -85,4 +86,15 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+func doBeforeRunCmd(cmd *cobra.Command, args []string) error {
+	debug, err := cmd.Flags().GetBool("debug")
+	if err != nil {
+		panic(err)
+	}
+	if debug {
+		log.SetLevel(log.DebugLevel)
+	}
+	return nil
 }

--- a/cmd/ocidist/cmd/soci.go
+++ b/cmd/ocidist/cmd/soci.go
@@ -29,9 +29,10 @@ var sociCmd = &cobra.Command{
 }
 
 var sociInspectCmd = &cobra.Command{
-	Use:   "inspect <URI>",
-	Short: "inspect a Signed OCI (soci) image",
-	RunE:  runSociInspect,
+	Use:     "inspect <URI>",
+	Short:   "inspect a Signed OCI (soci) image",
+	RunE:    runSociInspect,
+	PreRunE: doBeforeRunCmd,
 }
 
 var sociGetCmd = &cobra.Command{
@@ -45,7 +46,8 @@ $ ocidist soci get ocidist://localhost:5000/product/services/svc:v1.2
  "signature": {},
 }
 `,
-	RunE: runSociGet,
+	RunE:    runSociGet,
+	PreRunE: doBeforeRunCmd,
 }
 
 func runSociInspect(cmd *cobra.Command, args []string) error {
@@ -132,6 +134,7 @@ func init() {
 	sociInspectCmd.PersistentFlags().StringP("ca-file", "c", "", "verify soci cert is issued from specified CA and still valid")
 
 	sociCmd.PersistentFlags().BoolP("tls-verify", "T", true, "toggle tls verification")
+	sociCmd.PersistentFlags().BoolP("debug", "d", false, "enable debug output")
 
 	sociCmd.AddCommand(sociInspectCmd)
 	sociCmd.AddCommand(sociGetCmd)

--- a/pkg/api/ocidist.go
+++ b/pkg/api/ocidist.go
@@ -35,8 +35,11 @@ func NewOCIDistRepo(url *url.URL, config *OCIAPIConfig) (*OCIDistRepo, error) {
 func (odr *OCIDistRepo) BasePath() string {
 	scheme := odr.url.Scheme
 	switch odr.url.Scheme {
-	case "ocidist":
+	case "ocidist", "docker":
 		scheme = "http"
+	}
+	if odr.config.TLSVerify {
+		scheme += "s"
 	}
 	return fmt.Sprintf("%s://%s", scheme, odr.url.Host)
 }


### PR DESCRIPTION
HTTP clients/endpoints don't expect getting docker:// and panic.  Fix
by transforming the docker:// scheme to the appropriate http/https
value.

- Also add --debug flag to ocidist commands

Fixes: #1