### PR TITLE
Fix ocidist:// GetImage API call

### DIFF
--- a/pkg/api/ocidist.go
+++ b/pkg/api/ocidist.go
@@ -154,7 +154,7 @@ func (odr *OCIDistRepo) GetImage(image *ispec.Descriptor) (*ispec.Image, error) 
 	)
 
 	req := client.NewRequest(
-		reggie.GET, "/v2/<name>/referrers/<digest>",
+		reggie.GET, "/v2/<name>/blobs/<digest>",
 		reggie.WithName(repoPath),
 		reggie.WithDigest(string(image.Digest)))
 


### PR DESCRIPTION
Copy-paste error when adding GetReferrers API and broke GetImage which should use /blobs/<digest> not /referrers/<digest>